### PR TITLE
Adds the Admin Helpscout Beacon and help page redirects

### DIFF
--- a/config/install/ucb_admin_menus.configuration.yml
+++ b/config/install/ucb_admin_menus.configuration.yml
@@ -1,0 +1,1 @@
+admin_helpscout_beacon_id: '1bb01225-0287-4443-a7e5-be8f375a7766'

--- a/css/admin-helpscout-beacon.css
+++ b/css/admin-helpscout-beacon.css
@@ -1,0 +1,1 @@
+#hs-beacon iframe {background:rgba(0,0,0,.75) !important; }

--- a/js/admin-helpscout-beacon.js
+++ b/js/admin-helpscout-beacon.js
@@ -1,0 +1,22 @@
+(function(Drupal) {
+	Drupal.behaviors.adminHelpscoutBeacon = {
+		attach: function (context, drupalSettings) {
+			const helpElement = document.querySelector('.menu-item__help-main a');
+			if(!helpElement) return;
+			const settings = drupalSettings['admin_helpscout_beacon'];
+			!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+			Beacon('init', settings['id']);
+			Beacon('prefill', settings['prefill']);
+			Beacon('config', {
+				'display': {
+					'style': 'manual',
+					'iconImage': 'message'
+				}
+			});
+			helpElement.onclick = function(event) {
+				event.preventDefault();
+				Beacon('open');
+			};
+		}
+	};
+})(Drupal);

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\ucb_admin_menus\Controller\HelpController.
+ */
+
+namespace Drupal\ucb_admin_menus\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+
+class HelpController extends ControllerBase {
+	/**
+	 * @return \Drupal\Core\Routing\TrustedRedirectResponse
+	 *   A redirect to the CU Boulder web support site.
+	 */
+	public function helpRedirect() {
+		return new TrustedRedirectResponse('https://websupport.colorado.edu/');
+	}
+}

--- a/ucb_admin_menus.info.yml
+++ b/ucb_admin_menus.info.yml
@@ -1,10 +1,11 @@
 name: CU Boulder Admin Menus
 description: 'Provides custom admin menus for CU Boulder sites.'
 type: module
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.5 || 10'
 dependencies:
   - admin_toolbar_tools
+  - help # this module has routes that override those in help
   - node
   - system
-version: '1.0'
+version: '1.1'
 package: CU Boulder

--- a/ucb_admin_menus.install
+++ b/ucb_admin_menus.install
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * v1.1 – Admin Helpscout Beacon moved to ucb_admin_menus (CuBoulder/ucb_admin_menus#2).
+ */
+function ucb_admin_menus_update_9501() {
+	$config = \Drupal::configFactory()->getEditable('ucb_admin_menus.configuration');
+	$config->set('admin_helpscout_beacon_id', '1bb01225-0287-4443-a7e5-be8f375a7766')->save();
+}

--- a/ucb_admin_menus.libraries.yml
+++ b/ucb_admin_menus.libraries.yml
@@ -1,0 +1,9 @@
+admin_helpscout_beacon:
+  version: 1.0
+  js:
+    js/admin-helpscout-beacon.js: {}
+  css:
+    theme:
+      css/admin-helpscout-beacon.css: {}
+  dependencies:
+    - core/drupalSettings

--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Adds the Helpscout Beacon widget if the user has permission to see the admin toolbar.
+ * Implements hook_page_attachments_alter().
+ */
+function ucb_admin_menus_page_attachments_alter(array &$page) {
+	$user = \Drupal::currentUser();
+	if ($user->hasPermission('access toolbar')) {
+		/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
+		$configuration = \Drupal::configFactory()->get('ucb_admin_menus.configuration');
+		$roles = join(', ', $user->getRoles());
+  		$site_name = \Drupal::config('system.site')->get('name');
+		$site_name = str_replace(' ', '-', $site_name);
+		$site_name = preg_replace('/[^A-Za-z0-9\-]/', '', $site_name);
+		$page['#attached']['library'][] = 'ucb_admin_menus/admin_helpscout_beacon';
+		$page['#attached']['drupalSettings']['admin_helpscout_beacon'] = [
+			'id' => $configuration->get('admin_helpscout_beacon_id'),
+			'prefill' => [
+				'name' => $user->getDisplayName(),
+				'email' => $user->getEmail(),
+				'user_email' => $user->getEmail(),
+				'roles' => $roles,
+				'site_name' => $site_name,
+				'site_url' => (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri()
+			]
+		];
+	}
+}

--- a/ucb_admin_menus.routing.yml
+++ b/ucb_admin_menus.routing.yml
@@ -52,3 +52,19 @@ ucb_admin_menus.content_groups.people:
     _entity_create_any_access: 'node'
   options:
     _admin_route: true
+
+help.main:
+  path: /admin/help
+  defaults:
+    _controller: 'Drupal\ucb_admin_menus\Controller\HelpController::helpRedirect'
+    _title: 'Help'
+  requirements:
+    _permission: access administration pages
+
+help.page:
+  path: '/admin/help/{name}'
+  defaults:
+    _controller: 'Drupal\ucb_admin_menus\Controller\HelpController::helpRedirect'
+    _title: 'Help'
+  requirements:
+    _permission: access administration pages


### PR DESCRIPTION
- Admin Helpscout Beacon and help page redirects moved to ucb_admin_menus (resolves CuBoulder/ucb_admin_menus#2).
- Now indicates D10 compatibility.

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/17)