### PR TITLE
Hides administration items that a user doesn't have access to

### DIFF
--- a/src/Controller/OverviewController.php
+++ b/src/Controller/OverviewController.php
@@ -7,9 +7,11 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Menu\MenuActiveTrailInterface;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class OverviewController extends ControllerBase {
+	use StringTranslationTrait;
 
 	/**
 	 * The menu link tree service.
@@ -67,6 +69,7 @@ class OverviewController extends ControllerBase {
 			['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
 		];
 		$tree = $this->menuLinkTree->transform($tree, $manipulators);
+		$content = [];
 		foreach ($tree as $key => $element) {
 			// Only render accessible links.
 			if (!$element->access->isAllowed()) {
@@ -92,7 +95,7 @@ class OverviewController extends ControllerBase {
 				'#content' => $content,
 			];
 		} else return [
-			'#markup' => t('There are no content types to add.'),
+			'#markup' => $this->t('There are no items that you have access to.'),
 		];
 	}
 
@@ -146,7 +149,7 @@ class OverviewController extends ControllerBase {
 			return $build;
 		} else {
 			$build = [
-				'#markup' => $this->t('There are no content types to add.'),
+				'#markup' => $this->t('There are no items that you have access to.'),
 			];
 			$tree_access_cacheability->applyTo($build);
 			return $build;

--- a/ucb_admin_menus.info.yml
+++ b/ucb_admin_menus.info.yml
@@ -6,6 +6,5 @@ dependencies:
   - admin_toolbar_tools
   - help # this module has routes that override those in help
   - node
-  - system
-version: '1.1'
+version: '1.1.1'
 package: CU Boulder

--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -7,8 +7,7 @@
 function ucb_admin_menus_page_attachments_alter(array &$page) {
 	$user = \Drupal::currentUser();
 	if ($user->hasPermission('access toolbar')) {
-		/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
-		$configuration = \Drupal::configFactory()->get('ucb_admin_menus.configuration');
+		$configuration = \Drupal::config('ucb_admin_menus.configuration');
 		$roles = join(', ', $user->getRoles());
   		$site_name = \Drupal::config('system.site')->get('name');
 		$site_name = str_replace(' ', '-', $site_name);


### PR DESCRIPTION
This update includes these changes across several repos:
- Hides inaccessible items from the Admin Toolbar by installing Admin Toolbar Links Access Filter
- Hides inaccessible items from "Add content" and "CU Boulder site settings"

CuBoulder/tiamat-theme#240; Author @TeddyBearX

Sister PRs in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/18), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/32)