### PR TITLE
Adds stylistic modifications to the secondary administration toolbar

### DIFF
--- a/css/admin-toolbar-enhancer.css
+++ b/css/admin-toolbar-enhancer.css
@@ -1,0 +1,63 @@
+/*
+ * Contains styles for the Gin admin toolbars.
+ */
+
+.gin-secondary-toolbar.gin-secondary-toolbar--frontend {
+	background: var(--gin-bg-app);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__link.gin-back-to-admin, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:link, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:visited {
+	color: var(--gin-color-primary);
+	padding: var(--gin-spacing-xs) var(--gin-spacing-m);
+	border-radius: var(--gin-border-s);
+	border: 2px solid var(--gin-color-primary);
+	box-shadow: 0 1px 2px var(--gin-color-primary-light);
+	transition: var(--gin-transition);
+	font-size: 0.79rem;
+	font-weight: var(--gin-font-weight-semibold);
+	padding-left: calc(var(--gin-spacing-m) + 1.185rem);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:hover, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:active, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:focus {
+	color: var(--gin-color-button-text);
+	background-color: var(--gin-color-primary-hover);
+	border-color: var(--gin-color-primary-hover);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:active {
+	background-color: var(--gin-color-primary-active);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:focus {
+	background-color: var(--gin-color-primary-active);
+	border-color: var(--gin-color-focus-border);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin .placeholder, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:link .placeholder, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:visited .placeholder {
+	color: var(--gin-color-primary);
+	font-weight: var(--gin-font-weight-semibold);
+	transition: var(--gin-transition);
+	cursor: pointer;
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:hover .placeholder, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:active .placeholder, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:focus .placeholder {
+	color: var(--gin-color-button-text);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin::before {
+	background-color: var(--gin-color-primary);
+	mask-image: url('../../../../themes/contrib/gin/dist/media/sprite.svg#media-edit-view');
+	-webkit-mask-image: url('../../../../themes/contrib/gin/dist/media/sprite.svg#media-edit-view');
+	width: 0.79rem;
+	height: 0.79rem;
+	margin-left: var(--gin-spacing-m);
+	transition: var(--gin-transition);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:hover::before, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:active::before, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:focus::before {
+	background-color: var(--gin-color-button-text);
+}
+
+.gin-secondary-toolbar .gin-breadcrumb__list {
+	overflow: visible;
+}

--- a/css/admin-toolbar-enhancer.css
+++ b/css/admin-toolbar-enhancer.css
@@ -8,12 +8,13 @@
 
 .gin-secondary-toolbar .gin-breadcrumb__link.gin-back-to-admin, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:link, .gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link.gin-back-to-admin:visited {
 	color: var(--gin-color-primary);
-	padding: var(--gin-spacing-xs) var(--gin-spacing-m);
+	padding: 0 var(--gin-spacing-m);
 	border-radius: var(--gin-border-s);
 	border: 2px solid var(--gin-color-primary);
 	box-shadow: 0 1px 2px var(--gin-color-primary-light);
 	transition: var(--gin-transition);
 	font-size: 0.79rem;
+	line-height: 2rem;
 	font-weight: var(--gin-font-weight-semibold);
 	padding-left: calc(var(--gin-spacing-m) + 1.185rem);
 }
@@ -58,13 +59,9 @@
 	background-color: var(--gin-color-button-text);
 }
 
-.gin-secondary-toolbar .gin-breadcrumb__list {
-	overflow: visible;
-}
-
-a.gin-breadcrumb__link {
-    max-width: 300px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline-block;
+.gin-secondary-toolbar .gin-breadcrumb__item .gin-breadcrumb__link {
+	max-width: 300px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: inline-block;
 }

--- a/css/admin-toolbar-enhancer.css
+++ b/css/admin-toolbar-enhancer.css
@@ -61,3 +61,10 @@
 .gin-secondary-toolbar .gin-breadcrumb__list {
 	overflow: visible;
 }
+
+a.gin-breadcrumb__link {
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+}

--- a/ucb_admin_menus.libraries.yml
+++ b/ucb_admin_menus.libraries.yml
@@ -7,3 +7,9 @@ admin_helpscout_beacon:
       css/admin-helpscout-beacon.css: {}
   dependencies:
     - core/drupalSettings
+
+admin_toolbar_enhancer:
+  version: 1.0
+  css:
+    theme:
+      css/admin-toolbar-enhancer.css: {}

--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -24,5 +24,6 @@ function ucb_admin_menus_page_attachments_alter(array &$page) {
 				'site_url' => (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri()
 			]
 		];
+		$page['#attached']['library'][] = 'ucb_admin_menus/admin_toolbar_enhancer';
 	}
 }


### PR DESCRIPTION
This update:
- Modifies the "Edit" button on the secondary administration toolbar to actually look like a button
- Changes the background of the secondary administration toolbar to the off-white of administration pages, increasing noticeability of the toolbar

Resolves CuBoulder/tiamat-theme#282; Author @TeddyBearX 