### PR TITLE
Modifies the help text under link URI fields in the admin content editor interface

### DIFF
--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -27,3 +27,21 @@ function ucb_admin_menus_page_attachments_alter(array &$page) {
 		$page['#attached']['library'][] = 'ucb_admin_menus/admin_toolbar_enhancer';
 	}
 }
+
+/**
+ * [CuBoulder/tiamat-theme#406](https://github.com/CuBoulder/tiamat-theme/issues/406) – Modifies the help text under link URI fields.
+ * Implements hook_field_widget_single_element_form_alter().
+ */
+function ucb_admin_menus_field_widget_single_element_form_alter(array &$element, \Drupal\Core\Form\FormStateInterface $form_state, array $context) {
+	$field_definition = $context['items']->getFieldDefinition();
+	if ($field_definition->getType() == 'link') {
+		$element['uri']['#description'] = t(
+			'Start typing the title of a piece of content to select it. You can also enter an internal path such as %intpath or an external URL such as %exturl. Enter %frontpath to link to the front page.',
+			[
+				'%intpath' => '/about',
+				'%exturl' => 'https://www.colorado.edu',
+				'%frontpath' => '<front>'
+			]
+		);
+	}
+}


### PR DESCRIPTION
The help text under all link URI fields in the admin content editor interface has been updated to address concerns with the default help text causing confusion among users.

Resolves CuBoulder/tiamat-theme#406

Resolves CuBoulder/tiamat-theme#308 (last remaining work item)