### PR TITLE
Removes broken how-to page link in add content page (v1.2.1)

### DIFF
--- a/ucb_admin_menus.info.yml
+++ b/ucb_admin_menus.info.yml
@@ -6,5 +6,5 @@ dependencies:
   - admin_toolbar_tools
   - help # this module has routes that override those in help
   - node
-version: '1.2'
+version: '1.2.1'
 package: CU Boulder

--- a/ucb_admin_menus.links.menu.yml
+++ b/ucb_admin_menus.links.menu.yml
@@ -41,20 +41,14 @@ ucb_admin_menus.node.add.basic_page:
   class: 'Drupal\ucb_admin_menus\Plugin\Menu\NodeTypeMenuLink'
   parent: ucb_admin_menus.content_groups.general
   weight: 0
-ucb_admin_menus.node.add.how_to_page:
-  class: 'Drupal\ucb_admin_menus\Plugin\Menu\NodeTypeMenuLink'
-  parent: ucb_admin_menus.content_groups.general
-  weight: 1
-
 ucb_admin_menus.node.add.ucb_faq_page:
   class: 'Drupal\ucb_admin_menus\Plugin\Menu\NodeTypeMenuLink'
   parent: ucb_admin_menus.content_groups.general
-  weight: 2
-
+  weight: 1
 ucb_admin_menus.node.add.collection_item_page:
   class: 'Drupal\ucb_admin_menus\Plugin\Menu\NodeTypeMenuLink'
   parent: ucb_admin_menus.content_groups.general
-  weight: 3
+  weight: 2
 
 # --- News and Articles ---
 ucb_admin_menus.node.add.ucb_article:


### PR DESCRIPTION
[Remove] Removes broken how-to page link in add content page. CuBoulder/tiamat-custom-entities#129; Resolves CuBoulder/ucb_admin_menus#27