### PR TITLE
Adds logout route override and updates route overrride handling (1.3.0)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-	"files.associations": {
-		"*.install": "php",
-		"*.module": "php",
-		"*.profile": "php",
-		"*.theme": "php",
-		"*.inc": "php"
-	}
+  "files.associations": {
+    "*.install": "php",
+    "*.module": "php",
+    "*.profile": "php",
+    "*.theme": "php",
+    "*.inc": "php"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "cu-boulder/ucb_admin_menus",
-	"description": "Provides custom admin menus for CU Boulder sites.",
-	"license": "GPL-2.0-or-later",
-	"type": "drupal-custom-module"
+    "name": "cu-boulder/ucb_admin_menus",
+    "description": "Provides custom admin menus for CU Boulder sites.",
+    "license": "GPL-2.0-or-later",
+    "type": "drupal-custom-module"
 }

--- a/config/install/ucb_admin_menus.configuration.yml
+++ b/config/install/ucb_admin_menus.configuration.yml
@@ -1,1 +1,1 @@
-admin_helpscout_beacon_id: '1bb01225-0287-4443-a7e5-be8f375a7766'
+admin_helpscout_beacon_id: 7aeb6f1c-247c-4a83-b44f-4cee2784bb63

--- a/css/admin-helpscout-beacon.css
+++ b/css/admin-helpscout-beacon.css
@@ -1,1 +1,3 @@
-#hs-beacon iframe {background:rgba(0,0,0,.75) !important; }
+#hs-beacon iframe {
+  background: rgba(0, 0, 0, .75) !important;
+}

--- a/css/admin-toolbar-enhancer.css
+++ b/css/admin-toolbar-enhancer.css
@@ -1,41 +1,42 @@
 /* Preview View Mode Menu */
 div.node-preview-container.container-inline {
-    display: block;
-    position: inherit;
+  display: block;
+  position: inherit;
 }
+
 /* Back to Editing Button */
-.node-preview-backlink{
-	margin-left: 10px;
+.node-preview-backlink {
+  margin-left: 10px;
 }
 
 .node-preview-backlink::before {
-    content: '\f053  ' !important;
-    font-weight: 900 !important;
-    font-family: "Font Awesome 6 Free - Solid" ;
-    color: #0277bd;
+  content: '\f053  ' !important;
+  font-weight: 900 !important;
+  font-family: "Font Awesome 6 Free - Solid";
+  color: #0277bd;
 }
 
 .node-preview-backlink:hover::before {
-	color: #b71c1c !important;
+  color: #b71c1c !important;
 }
 
 /* Dropdown */
-#edit-view-mode{
-	min-width: 150px;
+#edit-view-mode {
+  min-width: 150px;
 }
 
 /* Mobile */
 @media (max-width: 575px) {
-	.node-preview-form-select{
-		display: flex;
-		flex-direction: column;
-	}
-	
-	.node-preview-form-select > * {
-		padding: 10px 0px;
-	}
-
-	.node-preview-backlink{
-		align-self: center;
-	}
+  .node-preview-form-select {
+    display: flex;
+    flex-direction: column;
   }
+
+  .node-preview-form-select > * {
+    padding: 10px 0px;
+  }
+
+  .node-preview-backlink {
+    align-self: center;
+  }
+}

--- a/js/admin-helpscout-beacon.js
+++ b/js/admin-helpscout-beacon.js
@@ -1,10 +1,10 @@
-(function(Drupal) {
+(function (Drupal) {
   Drupal.behaviors.adminHelpscoutBeacon = {
     attach: function (context, drupalSettings) {
       const helpElement = document.querySelector('.toolbar-icon-help-main') || document.querySelector('.menu-item__help-main a');
-      if(!helpElement) return;
+      if (!helpElement) return;
       const settings = drupalSettings['admin_helpscout_beacon'];
-      !function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+      !function (e, t, n) { function a() { var e = t.getElementsByTagName("script")[0], n = t.createElement("script"); n.type = "text/javascript", n.async = !0, n.src = "https://beacon-v2.helpscout.net", e.parentNode.insertBefore(n, e) } if (e.Beacon = n = function (t, n, a) { e.Beacon.readyQueue.push({ method: t, options: n, data: a }) }, n.readyQueue = [], "complete" === t.readyState) return a(); e.attachEvent ? e.attachEvent("onload", a) : e.addEventListener("load", a, !1) }(window, document, window.Beacon || function () { });
       Beacon('init', settings['id']);
       Beacon('prefill', settings['prefill']);
       Beacon('config', {
@@ -13,7 +13,7 @@
           'iconImage': 'message'
         }
       });
-      helpElement.onclick = function(event) {
+      helpElement.onclick = function (event) {
         event.preventDefault();
         Beacon('open');
       };

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -1,21 +1,23 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_admin_menus\Controller\HelpController.
- */
-
 namespace Drupal\ucb_admin_menus\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 
+/**
+ * Provides a controller for the Drupal help route.
+ */
 class HelpController extends ControllerBase {
-	/**
-	 * @return \Drupal\Core\Routing\TrustedRedirectResponse
-	 *   A redirect to the CU Boulder web support site.
-	 */
-	public function helpRedirect() {
-		return new TrustedRedirectResponse('https://websupport.colorado.edu/');
-	}
+
+  /**
+   * Redirects the Drupal help route to CU Boulder web support.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   A redirect response.
+   */
+  public function helpRedirect() {
+    return new TrustedRedirectResponse('https://websupport.colorado.edu/');
+  }
+
 }

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\ucb_admin_menus\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Session\AnonymousUserSession;
+use Drupal\Core\Session\SessionManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for the Drupal logout route.
+ */
+class LogoutController extends ControllerBase {
+
+  /**
+   * The session manager.
+   *
+   * @var \Drupal\Core\Session\SessionManagerInterface
+   */
+  private $session;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  private $user;
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private $logger;
+
+  /**
+   * Constructs a new LogoutController.
+   *
+   * @param \Drupal\Core\Session\SessionManagerInterface $session
+   *   The session manager.
+   * @param \Drupal\Core\Session\AccountProxyInterface $user
+   *   The current user.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger.
+   */
+  public function __construct(SessionManagerInterface $session, AccountProxyInterface $user, LoggerInterface $logger) {
+    $this->session = $session;
+    $this->user = $user;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('session_manager'),
+      $container->get('current_user'),
+      $container->get('logger.factory')->get('ucb_admin_menus')
+    );
+  }
+
+  /**
+   * Redirects the Drupal logout route to the site homepage.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   A redirect response.
+   */
+  public function logoutRedirect() {
+    if ($this->user->isAuthenticated()) {
+      // @see core/modules/user/user.module user_logout
+      $this->logger->info('Session closed for %name.', [
+        '%name' => $this->user->getAccountName(),
+      ]);
+      $this->moduleHandler()->invokeAllWith('user_logout', function (callable $hook, string $module) {
+        // Stops simpleSAMLphp Authentication from redirecting logouts to a
+        // FedAuth error page.
+        if ($module != 'simplesamlphp_auth') {
+          call_user_func($hook, $this->user);
+        }
+      });
+      $this->session->destroy();
+      $this->user->setAccount(new AnonymousUserSession());
+    }
+    return new TrustedRedirectResponse(base_path());
+  }
+
+}

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Controller for the Drupal logout route.
+ * Provides a controller for the Drupal logout route.
  */
 class LogoutController extends ControllerBase {
 
@@ -65,6 +65,13 @@ class LogoutController extends ControllerBase {
 
   /**
    * Redirects the Drupal logout route to the site homepage.
+   *
+   * The user's current session is destroyed and a redirect to the site
+   * homepage is returned. All module `user_logout` hooks are called with one
+   * notable exception: simpleSAMLphp Authentication. This module was
+   * redirecting the user to a FedAuth error page instead of actually logging
+   * them out. See
+   * [issue #29](https://github.com/CuBoulder/ucb_admin_menus/issues/29).
    *
    * @return \Drupal\Core\Routing\TrustedRedirectResponse
    *   A redirect response.

--- a/src/Controller/OverviewController.php
+++ b/src/Controller/OverviewController.php
@@ -10,149 +10,160 @@ use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Provides a controller for the "Add content" page.
+ */
 class OverviewController extends ControllerBase {
-	use StringTranslationTrait;
+  use StringTranslationTrait;
 
-	/**
-	 * The menu link tree service.
-	 *
-	 * @var \Drupal\Core\Menu\MenuLinkTreeInterface
-	 */
-	protected $menuLinkTree;
+  /**
+   * The menu link tree service.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
+   */
+  protected $menuLinkTree;
 
-	/**
-	 * The active menu trail service.
-	 *
-	 * @var \Drupal\Core\Menu\MenuActiveTrailInterface
-	 */
-	protected $menuActiveTrail;
+  /**
+   * The active menu trail service.
+   *
+   * @var \Drupal\Core\Menu\MenuActiveTrailInterface
+   */
+  protected $menuActiveTrail;
 
-	/**
-	 * Constructs a new OverviewController.
-	 *
-	 * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menuLinkTree
-	 *   The menu link tree service.
-	 * @param \Drupal\Core\Menu\MenuActiveTrailInterface $menuActiveTrail
-     *   The active menu trail service.
-	 */
-	public function __construct(MenuLinkTreeInterface $menuLinkTree, MenuActiveTrailInterface $menuActiveTrail) {
-		$this->menuLinkTree = $menuLinkTree;
-		$this->menuActiveTrail = $menuActiveTrail;
-	}
+  /**
+   * Constructs a new OverviewController.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menuLinkTree
+   *   The menu link tree service.
+   * @param \Drupal\Core\Menu\MenuActiveTrailInterface $menuActiveTrail
+   *   The active menu trail service.
+   */
+  public function __construct(MenuLinkTreeInterface $menuLinkTree, MenuActiveTrailInterface $menuActiveTrail) {
+    $this->menuLinkTree = $menuLinkTree;
+    $this->menuActiveTrail = $menuActiveTrail;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public static function create(ContainerInterface $container) {
-		return new static(
-			$container->get('menu.link_tree'),
-			$container->get('menu.active_trail')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('menu.link_tree'),
+      $container->get('menu.active_trail')
+    );
+  }
 
-	/**
-	 * Provides a single menu overview page.
-	 * Uses code from Drupal\system\Controller\SystemOverviewPage::getAdminBlock
-	 * 
-	 * @return array
-	 *   A render array suitable for
-	 *   \Drupal\Core\Render\RendererInterface::render().
-	 */
-	public function singleMenuOverview($link_id) {
-		$link = $this->menuActiveTrail->getActiveLink('admin');
-		// Only find the children of this link.
-		$parameters = new MenuTreeParameters();
-		$parameters->setRoot($link_id)->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
-		$tree = $this->menuLinkTree->load(NULL, $parameters);
-		$manipulators = [
-			['callable' => 'menu.default_tree_manipulators:checkAccess'],
-			['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-		];
-		$tree = $this->menuLinkTree->transform($tree, $manipulators);
-		$content = [];
-		foreach ($tree as $key => $element) {
-			// Only render accessible links.
-			if (!$element->access->isAllowed()) {
-				// @todo Bubble cacheability metadata of both accessible and
-				//   inaccessible links. Currently made impossible by the way admin
-				//   blocks are rendered.
-				continue;
-			}
-		
-			/** @var \Drupal\Core\Menu\MenuLinkInterface $link */
-			$link = $element->link;
-			// Removes items that a user doesn't have access to
-			if(!$link->getUrlObject()->access()) continue;
-			$content[$key]['title'] = $link->getTitle();
-			$content[$key]['options'] = $link->getOptions();
-			$content[$key]['description'] = $link->getDescription();
-			$content[$key]['url'] = $link->getUrlObject();
-		}
-		if($content) {
-			ksort($content);
-			return [
-				'#theme' => 'admin_block_content',
-				'#content' => $content,
-			];
-		} else return [
-			'#markup' => $this->t('There are no items that you have access to.'),
-		];
-	}
+  /**
+   * Provides a single menu overview page.
+   *
+   * Uses code from Drupal\system\Controller\SystemOverviewPage::getAdminBlock.
+   *
+   * @return array
+   *   A render array suitable for
+   *   \Drupal\Core\Render\RendererInterface::render().
+   */
+  public function singleMenuOverview($link_id) {
+    $link = $this->menuActiveTrail->getActiveLink('admin');
+    // Only find the children of this link.
+    $parameters = new MenuTreeParameters();
+    $parameters->setRoot($link_id)->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
+    $tree = $this->menuLinkTree->load(NULL, $parameters);
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+    ];
+    $tree = $this->menuLinkTree->transform($tree, $manipulators);
+    $content = [];
+    foreach ($tree as $key => $element) {
+      // Only render accessible links.
+      if (!$element->access->isAllowed()) {
+        // @todo Bubble cacheability metadata of both accessible and
+        //   inaccessible links. Currently made impossible by the way admin
+        //   blocks are rendered.
+        continue;
+      }
+      /** @var \Drupal\Core\Menu\MenuLinkInterface $link */
+      $link = $element->link;
+      // Removes items that a user doesn't have access to.
+      if (!$link->getUrlObject()->access()) {
+        continue;
+      }
+      $content[$key]['title'] = $link->getTitle();
+      $content[$key]['options'] = $link->getOptions();
+      $content[$key]['description'] = $link->getDescription();
+      $content[$key]['url'] = $link->getUrlObject();
+    }
+    if ($content) {
+      ksort($content);
+      return [
+        '#theme' => 'admin_block_content',
+        '#content' => $content,
+      ];
+    }
+    else {
+      return [
+        '#markup' => $this->t('There are no items that you have access to.'),
+      ];
+    }
+  }
 
-	/**
-	 * Provides the add content overview page.
-	 * Uses code from Drupal\system\Controller\SystemOverviewPage::overview
-	 *
-	 * @param string $link_id
-	 *   The ID of the administrative path link for which to display child links.
-	 *
-	 * @return array
-	 *   A render array suitable for
-	 *   \Drupal\Core\Render\RendererInterface::render().
-	 */
-	public function multiMenuOverview($link_id) {
-		$parameters = new MenuTreeParameters();
-		$parameters->setRoot($link_id)->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
-		$tree = $this->menuLinkTree->load(NULL, $parameters);
-		$manipulators = [
-			['callable' => 'menu.default_tree_manipulators:checkAccess'],
-			['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-		];
-		$tree = $this->menuLinkTree->transform($tree, $manipulators);
-		$tree_access_cacheability = new CacheableMetadata();
-		$blocks = [];
-		foreach ($tree as $key => $element) {
-			$tree_access_cacheability = $tree_access_cacheability->merge(CacheableMetadata::createFromObject($element->access));
-		
-			// Only render accessible links.
-			if (!$element->access->isAllowed()) {
-				continue;
-			}
-		
-			$link = $element->link;
-			$block['title'] = $link->getTitle();
-			$block['description'] = $link->getDescription();
-			$block['content'] = $this->singleMenuOverview($link->getPluginId());
-		
-			if (!empty($block['content']['#content'])) {
-				$blocks[$key] = $block;
-			}
-		}
-	
-		if ($blocks) {
-			ksort($blocks);
-			$build = [
-				'#theme' => 'admin_page',
-				'#blocks' => $blocks,
-			];
-			$tree_access_cacheability->applyTo($build);
-			return $build;
-		} else {
-			$build = [
-				'#markup' => $this->t('There are no items that you have access to.'),
-			];
-			$tree_access_cacheability->applyTo($build);
-			return $build;
-		}	
-	}
+  /**
+   * Provides the add content overview page.
+   *
+   * Uses code from Drupal\system\Controller\SystemOverviewPage::overview.
+   *
+   * @param string $link_id
+   *   The ID of the administrative path link for which to display child links.
+   *
+   * @return array
+   *   A render array suitable for
+   *   \Drupal\Core\Render\RendererInterface::render().
+   */
+  public function multiMenuOverview($link_id) {
+    $parameters = new MenuTreeParameters();
+    $parameters->setRoot($link_id)->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
+    $tree = $this->menuLinkTree->load(NULL, $parameters);
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+    ];
+    $tree = $this->menuLinkTree->transform($tree, $manipulators);
+    $tree_access_cacheability = new CacheableMetadata();
+    $blocks = [];
+    foreach ($tree as $key => $element) {
+      $tree_access_cacheability = $tree_access_cacheability->merge(CacheableMetadata::createFromObject($element->access));
+
+      // Only render accessible links.
+      if (!$element->access->isAllowed()) {
+        continue;
+      }
+
+      $link = $element->link;
+      $block['title'] = $link->getTitle();
+      $block['description'] = $link->getDescription();
+      $block['content'] = $this->singleMenuOverview($link->getPluginId());
+
+      if (!empty($block['content']['#content'])) {
+        $blocks[$key] = $block;
+      }
+    }
+
+    if ($blocks) {
+      ksort($blocks);
+      $build = [
+        '#theme' => 'admin_page',
+        '#blocks' => $blocks,
+      ];
+      $tree_access_cacheability->applyTo($build);
+      return $build;
+    }
+    else {
+      $build = [
+        '#markup' => $this->t('There are no items that you have access to.'),
+      ];
+      $tree_access_cacheability->applyTo($build);
+      return $build;
+    }
+  }
+
 }

--- a/src/NodeTypeBreadcrumbBuilder.php
+++ b/src/NodeTypeBreadcrumbBuilder.php
@@ -10,62 +10,71 @@ use Drupal\Core\Menu\MenuLinkManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 
+/**
+ * Builds breadcrumbs for the node add pages to include the parent category.
+ *
+ * When adding an Article node, for example, the breadcrumb becomes Home → Add
+ * content → News and Articles.
+ */
 class NodeTypeBreadcrumbBuilder implements BreadcrumbBuilderInterface {
-	use StringTranslationTrait;
+  use StringTranslationTrait;
 
-	/**
-	 * The menu link manager service.
-	 *
-	 * @var \Drupal\Core\Menu\MenuLinkManagerInterface
-	 */
-	protected $menuLinkManager;
+  /**
+   * The menu link manager service.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkManagerInterface
+   */
+  protected $menuLinkManager;
 
-	/**
-	 * Constructs a new NodeTypeBreadcrumbBuilder.
-	 * 
-	 * @param \Drupal\Core\Menu\MenuLinkManagerInterface $menuLinkManager
-	 *   The menu link manager service.
-	 */
-	public function __construct(MenuLinkManagerInterface $menuLinkManager) {
-		$this->menuLinkManager = $menuLinkManager;
-	}
+  /**
+   * Constructs a new NodeTypeBreadcrumbBuilder.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkManagerInterface $menuLinkManager
+   *   The menu link manager service.
+   */
+  public function __construct(MenuLinkManagerInterface $menuLinkManager) {
+    $this->menuLinkManager = $menuLinkManager;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function applies(RouteMatchInterface $route_match) {
-		return $route_match->getRouteName() == 'node.add';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    return $route_match->getRouteName() == 'node.add';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function build(RouteMatchInterface $route_match) {
-		// Establishes the root of the trail
-		/** @var \Drupal\node\NodeTypeInterface $nodeType */
-		$nodeType = $route_match->getParameter('node_type');
-		$breadcrumb = new Breadcrumb();
-		$breadcrumb
-			->addLink(Link::createFromRoute($this->t('Home'), '<front>'))
-			->addLink(Link::createFromRoute($this->t('Add content'), 'node.add_page'));
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    // Establishes the root of the trail.
+    /** @var \Drupal\node\NodeTypeInterface $nodeType */
+    $nodeType = $route_match->getParameter('node_type');
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb
+      ->addLink(Link::createFromRoute($this->t('Home'), '<front>'))
+      ->addLink(Link::createFromRoute($this->t('Add content'), 'node.add_page'));
 
-		try {
-			// Adds the parent link from this module's overview pages
-			/** @var \Drupal\Core\Menu\MenuLinkInterface $link */
-			$link = $this->menuLinkManager->createInstance('ucb_admin_menus.node.add.' . $nodeType->id());
-			$parentId = $link->getParent();
-			if($parentId) {
-				/** @var \Drupal\Core\Menu\MenuLinkInterface $parentLink */
-				$parentLink = $this->menuLinkManager->createInstance($parentId);
-				$breadcrumb->addLink(Link::createFromRoute($parentLink->getTitle(), $parentLink->getRouteName(), $parentLink->getRouteParameters()));
-				$breadcrumb->addCacheableDependency($parentLink);
-			}
-		} catch(PluginException $e) {}
+    try {
+      // Adds the parent link from this module's overview pages.
+      /** @var \Drupal\Core\Menu\MenuLinkInterface $link */
+      $link = $this->menuLinkManager->createInstance('ucb_admin_menus.node.add.' . $nodeType->id());
+      $parentId = $link->getParent();
+      if ($parentId) {
+        /** @var \Drupal\Core\Menu\MenuLinkInterface $parentLink */
+        $parentLink = $this->menuLinkManager->createInstance($parentId);
+        $breadcrumb->addLink(Link::createFromRoute($parentLink->getTitle(), $parentLink->getRouteName(), $parentLink->getRouteParameters()));
+        $breadcrumb->addCacheableDependency($parentLink);
+      }
+    }
+    catch (PluginException $e) {
+    }
 
-		// Cache stuff
-		$breadcrumb->addCacheableDependency($nodeType);
-		$breadcrumb->addCacheContexts(['route']);
+    // Cache stuff.
+    $breadcrumb->addCacheableDependency($nodeType);
+    $breadcrumb->addCacheContexts(['route']);
 
-		return $breadcrumb;
-	}
+    return $breadcrumb;
+  }
+
 }

--- a/src/Plugin/Menu/NodeTypeMenuLink.php
+++ b/src/Plugin/Menu/NodeTypeMenuLink.php
@@ -7,97 +7,102 @@ use Drupal\Core\Menu\MenuLinkDefault;
 use Drupal\Core\Menu\StaticMenuLinkOverridesInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Provides a base class for menu links in the "Add content" page.
+ */
 class NodeTypeMenuLink extends MenuLinkDefault {
 
-	/**
-	 * The associated node type.
-	 *
-	 * @var \Drupal\node\NodeTypeInterface
-	 */
-	protected $nodeType;
+  /**
+   * The associated node type.
+   *
+   * @var \Drupal\node\NodeTypeInterface
+   */
+  protected $nodeType;
 
-	/**
-	 * Creates a new NodeTypeMenuLink.
-	 *
-	 * @param array $configuration
-	 *   A configuration array containing information about the plugin instance.
-	 * @param string $plugin_id
-	 *   The plugin_id for the plugin instance.
-	 * @param mixed $plugin_definition
-	 *   The plugin implementation definition.
-	 * @param \Drupal\Core\Menu\StaticMenuLinkOverridesInterface $static_override
-	 *   The static override storage.
-	 * @param \Drupal\Core\Entity\EntityStorageInterface
-	 *   The node type storage.
-	 */
-	public function __construct(array $configuration, $plugin_id, $plugin_definition, StaticMenuLinkOverridesInterface $static_override, EntityStorageInterface $entityStorage) {
-		parent::__construct($configuration, $plugin_id, $plugin_definition, $static_override);
-		// Gets the node type id from the menu link id
-		$menuLinkId = $this->pluginDefinition['id'];
-		$nodeTypeId = substr($menuLinkId, strripos($menuLinkId, '.node.add.') + 10);
-		// Loads the node type from the node type storage (falls back to basic page if it doesn't exist to avoid breaking the site)
-		$this->nodeType = $entityStorage->load($nodeTypeId) ?? $entityStorage->load('basic_page');
-	}
+  /**
+   * Creates a new NodeTypeMenuLink.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Menu\StaticMenuLinkOverridesInterface $static_override
+   *   The static override storage.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $entityStorage
+   *   The node type storage.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StaticMenuLinkOverridesInterface $static_override, EntityStorageInterface $entityStorage) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $static_override);
+    // Gets the node type id from the menu link id.
+    $menuLinkId = $this->pluginDefinition['id'];
+    $nodeTypeId = substr($menuLinkId, strripos($menuLinkId, '.node.add.') + 10);
+    // Loads the node type from the node type storage (falls back to basic
+    // page if it doesn't exist to avoid breaking the site).
+    $this->nodeType = $entityStorage->load($nodeTypeId) ?? $entityStorage->load('basic_page');
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-		return new static(
-			$configuration,
-			$plugin_id,
-			$plugin_definition,
-			$container->get('menu_link.static.overrides'),
-			$container->get('entity_type.manager')->getStorage('node_type')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('menu_link.static.overrides'),
+      $container->get('entity_type.manager')->getStorage('node_type')
+    );
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getTitle() {
-		return $this->nodeType->label();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getTitle() {
+    return $this->nodeType->label();
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getDescription() {
-		return $this->nodeType->getDescription();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->nodeType->getDescription();
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getRouteName() {
-		return 'node.add';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getRouteName() {
+    return 'node.add';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getRouteParameters() {
-		return ['node_type' => $this->nodeType->id()];
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getRouteParameters() {
+    return ['node_type' => $this->nodeType->id()];
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getCacheContexts() {
-		return $this->nodeType->getCacheContexts();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return $this->nodeType->getCacheContexts();
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getCacheTags() {
-		return $this->nodeType->getCacheTags();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return $this->nodeType->getCacheTags();
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getCacheMaxAge() {
-		return $this->nodeType->getCacheMaxAge();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return $this->nodeType->getCacheMaxAge();
+  }
+
 }

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\ucb_admin_menus\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events and makes overrides as necessary.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+
+    // Redirects help pages to Web Support.
+    if ($route = $collection->get('help.main')) {
+      $route->setDefault('_controller', 'Drupal\ucb_admin_menus\Controller\HelpController::helpRedirect');
+    }
+    if ($route = $collection->get('help.page')) {
+      $route->setDefault('_controller', 'Drupal\ucb_admin_menus\Controller\HelpController::helpRedirect');
+    }
+
+    // Replaces the default "Add content" page with the better one with
+    // categories.
+    if ($route = $collection->get('node.add_page')) {
+      $route->setDefault('_controller', 'Drupal\ucb_admin_menus\Controller\OverviewController::multiMenuOverview');
+      $route->setDefault('link_id', 'ucb_admin_menus.node.add');
+    }
+
+    // Stops simpleSAMLphp Authentication from redirecting logouts to a FedAuth
+    // error page.
+    if ($route = $collection->get('user.logout')) {
+      $route->setDefault('_controller', 'Drupal\ucb_admin_menus\Controller\LogoutController::logoutRedirect');
+    }
+
+  }
+
+}

--- a/ucb_admin_menus.info.yml
+++ b/ucb_admin_menus.info.yml
@@ -6,5 +6,5 @@ dependencies:
   - admin_toolbar_tools
   - help # this module has routes that override those in help
   - node
-version: '1.2.1'
+version: '1.2.2'
 package: CU Boulder

--- a/ucb_admin_menus.info.yml
+++ b/ucb_admin_menus.info.yml
@@ -4,7 +4,7 @@ type: module
 core_version_requirement: '^9.5 || ^10'
 dependencies:
   - admin_toolbar_tools
-  - help # this module has routes that override those in help
   - node
-version: '1.2.2'
+  - user
+version: '1.3.0'
 package: CU Boulder

--- a/ucb_admin_menus.install
+++ b/ucb_admin_menus.install
@@ -1,9 +1,16 @@
 <?php
 
 /**
- * v1.1 – Admin Helpscout Beacon moved to ucb_admin_menus (CuBoulder/ucb_admin_menus#2).
+ * @file
+ * Contains update hooks used by the CU Boulder Admin Menus module.
+ */
+
+/**
+ * Admin Helpscout Beacon moved to ucb_admin_menus.
+ *
+ * Introduced in v1.1 to address CuBoulder/ucb_admin_menus#2.
  */
 function ucb_admin_menus_update_9501() {
-	$config = \Drupal::configFactory()->getEditable('ucb_admin_menus.configuration');
-	$config->set('admin_helpscout_beacon_id', '1bb01225-0287-4443-a7e5-be8f375a7766')->save();
+  $config = \Drupal::configFactory()->getEditable('ucb_admin_menus.configuration');
+  $config->set('admin_helpscout_beacon_id', '1bb01225-0287-4443-a7e5-be8f375a7766')->save();
 }

--- a/ucb_admin_menus.install
+++ b/ucb_admin_menus.install
@@ -6,11 +6,11 @@
  */
 
 /**
- * Admin Helpscout Beacon moved to ucb_admin_menus.
+ * Updates Admin Helpscout Beacon id.
  *
- * Introduced in v1.1 to address CuBoulder/ucb_admin_menus#2.
+ * Introduced in version 1.3.0 to address CuBoulder/ucb_admin_menus#32.
  */
-function ucb_admin_menus_update_9501() {
+function ucb_admin_menus_update_9502() {
   $config = \Drupal::configFactory()->getEditable('ucb_admin_menus.configuration');
-  $config->set('admin_helpscout_beacon_id', '1bb01225-0287-4443-a7e5-be8f375a7766')->save();
+  $config->set('admin_helpscout_beacon_id', '7aeb6f1c-247c-4a83-b44f-4cee2784bb63')->save();
 }

--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -1,57 +1,67 @@
 <?php
 
-use \Drupal\Core\Form\FormStateInterface;
+/**
+ * @file
+ * Contains functional hooks used by the CU Boulder Admin Menus module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Adds the Helpscout Beacon widget if the user has permission to see the admin toolbar.
+ * Adds the Helpscout Beacon widget into the admin toolbar.
+ *
  * Implements hook_page_attachments_alter().
  */
 function ucb_admin_menus_page_attachments_alter(array &$page) {
-	$user = \Drupal::currentUser();
-	if ($user->hasPermission('access toolbar')) {
-		$configuration = \Drupal::config('ucb_admin_menus.configuration');
-		$roles = join(', ', $user->getRoles());
-  		$site_name = \Drupal::config('system.site')->get('name');
-		$site_name = str_replace(' ', '-', $site_name);
-		$site_name = preg_replace('/[^A-Za-z0-9\-]/', '', $site_name);
-		$page['#attached']['library'][] = 'ucb_admin_menus/admin_helpscout_beacon';
-		$page['#attached']['drupalSettings']['admin_helpscout_beacon'] = [
-			'id' => $configuration->get('admin_helpscout_beacon_id'),
-			'prefill' => [
-				'name' => $user->getDisplayName(),
-				'email' => $user->getEmail(),
-				'user_email' => $user->getEmail(),
-				'roles' => $roles,
-				'site_name' => $site_name,
-				'site_url' => (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri()
-			]
-		];
-		$page['#attached']['library'][] = 'ucb_admin_menus/admin_toolbar_enhancer';
-	}
+  $user = \Drupal::currentUser();
+  if ($user->hasPermission('access toolbar')) {
+    $configuration = \Drupal::config('ucb_admin_menus.configuration');
+    $roles = implode(', ', $user->getRoles());
+    $site_name = \Drupal::config('system.site')->get('name');
+    $site_name = str_replace(' ', '-', $site_name);
+    $site_name = preg_replace('/[^A-Za-z0-9\-]/', '', $site_name);
+    $page['#attached']['library'][] = 'ucb_admin_menus/admin_helpscout_beacon';
+    $page['#attached']['drupalSettings']['admin_helpscout_beacon'] = [
+      'id' => $configuration->get('admin_helpscout_beacon_id'),
+      'prefill' => [
+        'name' => $user->getDisplayName(),
+        'email' => $user->getEmail(),
+        'user_email' => $user->getEmail(),
+        'roles' => $roles,
+        'site_name' => $site_name,
+        'site_url' => (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri(),
+      ],
+    ];
+    $page['#attached']['library'][] = 'ucb_admin_menus/admin_toolbar_enhancer';
+  }
 }
 
 /**
- * [CuBoulder/tiamat-theme#406](https://github.com/CuBoulder/tiamat-theme/issues/406) – Modifies the help text under link URI fields.
+ * Modifies the help text under link URI fields.
+ *
+ * Introduced to address [CuBoulder/tiamat-theme#406](https://github.com/CuBoulder/tiamat-theme/issues/406).
+ *
  * Implements hook_field_widget_single_element_form_alter().
  */
 function ucb_admin_menus_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
-	$field_definition = $context['items']->getFieldDefinition();
-	if ($field_definition->getType() == 'link') {
-		$element['uri']['#description'] = t(
-			'Start typing the title of a piece of content to select it. You can also enter an internal path such as %intpath or an external URL such as %exturl. Enter %frontpath to link to the front page.',
-			[
-				'%intpath' => '/about',
-				'%exturl' => 'https://www.colorado.edu',
-				'%frontpath' => '<front>'
-			]
-		);
-	}
+  $field_definition = $context['items']->getFieldDefinition();
+  if ($field_definition->getType() == 'link') {
+    $element['uri']['#description'] = t(
+      'Start typing the title of a piece of content to select it. You can also enter an internal path such as %intpath or an external URL such as %exturl. Enter %frontpath to link to the front page.',
+      [
+        '%intpath' => '/about',
+        '%exturl' => 'https://www.colorado.edu',
+        '%frontpath' => '<front>',
+      ]
+    );
+  }
 }
 
 /**
  * Removes extra "HTML and style options" from menu blocks.
  *
- * Introduced in version 1.1.3 to address CuBoulder/tiamat-theme#267.
+ * Introduced in version 1.1.3 to address [CuBoulder/tiamat-theme#267](https://github.com/CuBoulder/tiamat-theme/issues/267).
+ *
  * Implements hook_form_alter().
  */
 function ucb_admin_menus_form_alter(&$form, FormStateInterface $form_state, $form_id) {

--- a/ucb_admin_menus.routing.yml
+++ b/ucb_admin_menus.routing.yml
@@ -1,14 +1,3 @@
-node.add_page:
-  path: '/node/add'
-  defaults:
-    _title: 'Add content'
-    _controller: 'Drupal\ucb_admin_menus\Controller\OverviewController::multiMenuOverview'
-    link_id: 'ucb_admin_menus.node.add'
-  requirements:
-    _entity_create_any_access: 'node'
-  options:
-    _node_operation_route: true
-
 ucb_admin_menus.content_groups.general:
   path: '/node/add/group/general'
   defaults:
@@ -63,19 +52,3 @@ ucb_admin_menus.content_groups.alumni_class_notes:
     _entity_create_any_access: 'node'
   options:
     _admin_route: true
-
-help.main:
-  path: /admin/help
-  defaults:
-    _controller: 'Drupal\ucb_admin_menus\Controller\HelpController::helpRedirect'
-    _title: 'Help'
-  requirements:
-    _permission: access administration pages
-
-help.page:
-  path: '/admin/help/{name}'
-  defaults:
-    _controller: 'Drupal\ucb_admin_menus\Controller\HelpController::helpRedirect'
-    _title: 'Help'
-  requirements:
-    _permission: access administration pages

--- a/ucb_admin_menus.services.yml
+++ b/ucb_admin_menus.services.yml
@@ -3,13 +3,15 @@ services:
     class: 'Drupal\ucb_admin_menus\NodeTypeBreadcrumbBuilder'
     arguments: ['@plugin.manager.menu.link']
     tags:
-      -
-        name: breadcrumb_builder
+      - name: breadcrumb_builder
         priority: 1010
+  ucb_admin_menus.route_subscriber:
+    class: Drupal\ucb_admin_menus\Routing\RouteSubscriber
+    tags:
+      - name: event_subscriber
   http_middleware.ucb_admin_menus_redirect_403:
     class: 'Drupal\ucb_admin_menus\Middleware\Redirect403'
     arguments: ['@current_user']
     tags:
-      -
-        name: http_middleware
+      - name: http_middleware
         priority: 30


### PR DESCRIPTION
This update:
- [Bug] Overrides the logout route to remove the simpleSAMLphp Authentication redirect and instead redirect the user to the homepage of the site after destroying the session. **This will need to be tested in the sandboxes to make sure it works properly since I have no way to test on a local development instance.** Resolves CuBoulder/ucb_admin_menus#29
- [Change] Adds a RouteSubscriber which is actually the proper way to override routes that already exist from Drupal or other modules. In addition to logout, this also affects the help and add content route overrides.
- [Change] Cleans up project files in accordance with Drupal coding standards (PHP CodeSniffer validation).
- [Change] Updates Admin Helpscout Beacon id to link to the new Drupal 10 documentation. Resolves CuBoulder/ucb_admin_menus#32