### PR TITLE
Initial solution to hiding "Clear Related Data"

### DIFF
--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -59,3 +59,13 @@ function ucb_admin_menus_form_alter(&$form, FormStateInterface $form_state, $for
     $form['settings']['style']['#access'] = FALSE;
   }
 }
+
+/**
+* Implements ucb_admin_menus_form_menu_edit_form_alter().
+*
+* Removes the 'Clear Related Data' button from the main menu navigation settings page
+*/
+function ucb_admin_menus_form_menu_edit_form_alter(array &$form, FormStateInterface $form_state) {
+    $form['actions']['clear'] = [
+    ];
+  }


### PR DESCRIPTION
Closes https://github.com/CuBoulder/ucb_admin_menus/issues/34.
Adds a hook to remove the "Clear Related Button" in the main menu settings page.