### PR TITLE
Corrects help redirect (v1.3.1)

### DIFF
--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -17,7 +17,7 @@ class HelpController extends ControllerBase {
    *   A redirect response.
    */
   public function helpRedirect() {
-    return new TrustedRedirectResponse('https://websupport.colorado.edu/');
+    return new TrustedRedirectResponse('https://webexpress.colorado.edu/');
   }
 
 }

--- a/ucb_admin_menus.info.yml
+++ b/ucb_admin_menus.info.yml
@@ -5,5 +5,5 @@ core_version_requirement: '^9.5 || ^10'
 dependencies:
   - admin_toolbar_tools
   - node
-version: '1.3.0'
+version: '1.3.1'
 package: CU Boulder

--- a/ucb_admin_menus.module
+++ b/ucb_admin_menus.module
@@ -71,11 +71,11 @@ function ucb_admin_menus_form_alter(&$form, FormStateInterface $form_state, $for
 }
 
 /**
-* Implements ucb_admin_menus_form_menu_edit_form_alter().
-*
-* Removes the 'Clear Related Data' button from the main menu navigation settings page
-*/
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Removes the 'Clear Related Data' button from the main menu navigation
+ * settings page.
+ */
 function ucb_admin_menus_form_menu_edit_form_alter(array &$form, FormStateInterface $form_state) {
-    $form['actions']['clear'] = [
-    ];
-  }
+  unset($form['actions']['clear']);
+}


### PR DESCRIPTION
This update corrects the `/admin/help` redirect to the [Drupal 10 documentation](https://webexpress.colorado.edu/).

[change] Resolves CuBoulder/ucb_admin_menus#38